### PR TITLE
ci(autodevops): remove the gitlab project id on the generated namespace

### DIFF
--- a/autodevops_simple_app.yml
+++ b/autodevops_simple_app.yml
@@ -157,6 +157,7 @@ Deploy app (prod):
       - master
   variables:
     HOST: ${CI_PROJECT_NAME}.${KUBE_INGRESS_BASE_DOMAIN}
+    K8S_NAMESPACE: ${CI_PROJECT_NAME}
   environment:
     name: prod
     url: https://${CI_PROJECT_NAME}.${KUBE_INGRESS_BASE_DOMAIN}


### PR DESCRIPTION
<img src=https://media.giphy.com/media/ZdO4NenDbsQNwUwKDB/giphy.gif width=693>

---

In production, the namespace should be the name of the startup