### PR TITLE
fix(app)!: do not override set production values

### DIFF
--- a/base_deploy_app_chart_stage.yml
+++ b/base_deploy_app_chart_stage.yml
@@ -27,17 +27,13 @@ variables:
         ${HELM_RENDER_ARGS}"
     # Set own certificate when deploying in prod environment
     - |-
-      if [[ -n "${PRODUCTION+x}" ]]; then
+      if [[ -z "${PRODUCTION+x}" ]]; then
         HELM_RENDER_ARGS=" \
-          --set ingress.annotations.certmanager\.k8s\.io/cluster-issuer=letsencrypt-prod \
-          --set-string ingress.annotations.kubernetes\.io/tls-acme=true \
-          --set tls[0].hosts.secretName=${CONTEXT}-crt \
-          ${HELM_RENDER_ARGS}"
-      else
-        HELM_RENDER_ARGS=" \
-          --set ingress.tls[0].secretName=wildcard-crt \
+          --set ingress.annotations.certmanager\.k8s\.io/cluster-issuer=null \
+          --set ingress.annotations.kubernetes\.io/tls-acme=null \
           --set ingress.hosts[0].host=${HOST} \
           --set ingress.tls[0].hosts[0]=${HOST} \
+          --set ingress.tls[0].secretName=wildcard-crt \
           ${HELM_RENDER_ARGS}"
       fi
 


### PR DESCRIPTION
<img src=https://media.giphy.com/media/YraAlmP4wjZzfv2qCk/giphy.gif width=693>

---

BREAKING CHANGE: **app_chart** do not override set production values
    As we use the production ready values in `values.socialgouv.yaml` of https://github.com/SocialGouv/helm-charts/tree/v6.0.0/charts/app, we only need to override the render when not in production