### PR TITLE
feat(autodevops)!: centralize environment in autodevops file

### DIFF
--- a/autodevops_simple_app.yml
+++ b/autodevops_simple_app.yml
@@ -78,6 +78,9 @@ Register image:
 
 Create namespace:
   extends: .base_create_namespace_stage
+  environment:
+    name: review/${CI_COMMIT_REF_NAME}-dev
+    url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_ID}.${KUBE_INGRESS_BASE_DOMAIN}
   only:
     refs:
       - branches
@@ -150,15 +153,22 @@ Deploy app (prod):
 Create Azure DB (dev):
   extends:
     - .base_create_azure_db
+  environment:
+    name: review/${CI_COMMIT_REF_NAME}-dev
 
 Drop Azure DB (dev):
   extends:
     - .base_drop_azure_db
+  environment:
+    name: review/${CI_COMMIT_REF_NAME}-dev
+    action: stop
 
 #
 
 Delete useless k8s namespaces:
   extends: .base_delete_useless_k8s_ns_stage
+  environment:
+    name: review/${CI_COMMIT_REF_NAME}-dev
   variables:
     K8S_NAMESPACE_PREFIX: "${PROJECT}-${CI_PROJECT_ID}-review"
 

--- a/base_azure_db_stage.yml
+++ b/base_azure_db_stage.yml
@@ -30,8 +30,6 @@
   allow_failure: true
   variables:
     NEW_DB_EXTENSIONS: pgcrypto
-  environment:
-    name: review/${CI_COMMIT_REF_NAME}-dev
   script:
     - export PGUSER="${ADMIN_PG_USER}"
     - export PGPASSWORD="${ADMIN_PG_PASSWORD}"
@@ -43,9 +41,6 @@
   stage: "Clean Up"
   when: manual
   allow_failure: true
-  environment:
-    name: review/${CI_COMMIT_REF_NAME}-dev
-    action: stop
   script:
     - export PGUSER="${ADMIN_PG_USER}"
     - export PGPASSWORD="${ADMIN_PG_PASSWORD}"

--- a/base_create_namespace_stage.yml
+++ b/base_create_namespace_stage.yml
@@ -7,9 +7,6 @@ variables:
 .base_create_namespace_stage:
   extends: .base_docker_kubectl_image_stage
   stage: "Registration"
-  environment:
-    name: review/${CI_COMMIT_REF_NAME}-dev
-    url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_ID}.${KUBE_INGRESS_BASE_DOMAIN}
   dependencies: []
   script:
     - echo "kubectl get namespace ${K8S_NAMESPACE}"

--- a/base_delete_useless_k8s_ns_stage.yml
+++ b/base_delete_useless_k8s_ns_stage.yml
@@ -8,7 +8,6 @@ variables:
   dependencies: []
   allow_failure: true
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/k8s-ns-killer:1.4.0
-  environment: fabrique-dev
   script:
     - git remote set-url origin https://github.com/${CI_PROJECT_PATH}.git
     - echo "k8s-ns-killer ${K8S_NAMESPACE_PREFIX}"

--- a/base_delete_useless_managed_postgresql_stage.yml
+++ b/base_delete_useless_managed_postgresql_stage.yml
@@ -5,7 +5,6 @@
   dependencies: []
   allow_failure: true
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/pg-cleaner:1.4.0
-  environment: fabrique-dev
   script:
     - python /bin/pg-cleaner.py
   only:


### PR DESCRIPTION
<img src=https://media.giphy.com/media/humzwleaMLtsinZlG3/giphy.gif width=693>

---

We remove the environment name entries in the job templates.
This helps reusing the `base_*` job templates

BREAKING CHANGE: **feat(autodevops)!: centralize environment in autodevops file**

Our autodevops now drives the environment info.

```diff

Azure db stage:
  extends: .base_azure_db_stage
+  environment:
+    name: ${CI_COMMIT_REF_NAME}-dev

Drop azure db:
  extends: .base_drop_azure_db
+  environment:
+    name: ${CI_COMMIT_REF_NAME}-dev

Create namespace stage:
  extends: .base_create_namespace_stage
+  environment:
+    name: ${CI_COMMIT_REF_NAME}-dev

Delete useless k8s ns stage:
  extends: .base_delete_useless_k8s_ns_stage
+  environment:
+    name: ${CI_COMMIT_REF_NAME}-dev

Delete useless managed postgresql:
  extends: .base_delete_useless_managed_postgresql_stage
+  environment:
+    name: ${CI_COMMIT_REF_NAME}-dev
```