### PR TITLE
feat(trivy): use image subcommand

### DIFF
--- a/base_trivy_scan.yml
+++ b/base_trivy_scan.yml
@@ -8,9 +8,9 @@
     IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   script:
     # Build report
-    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@/tmp/contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
+    - trivy image --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@/tmp/contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
     # Print report and fail on error
-    - trivy --exit-code 1 --cache-dir .trivycache/ --no-progress $IMAGE
+    - trivy image --exit-code 1 --cache-dir .trivycache/ --no-progress $IMAGE
   cache:
     paths:
       - .trivycache/


### PR DESCRIPTION
As `$ trivy IMAGE_NAME` is deprecated 
see https://github.com/SocialGouv/docker/pull/265