### PR TITLE
fix(trivy): change arguments order

### DIFF
--- a/base_trivy_scan.yml
+++ b/base_trivy_scan.yml
@@ -8,9 +8,9 @@
     IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
   script:
     # Build report
-    - trivy image --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@/tmp/contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
+    - trivy --cache-dir .trivycache/ image --exit-code 0 --no-progress --format template --template "@/tmp/contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE
     # Print report and fail on error
-    - trivy image --exit-code 1 --cache-dir .trivycache/ --no-progress $IMAGE
+    - trivy --cache-dir .trivycache/ image --exit-code 1 --no-progress $IMAGE
   cache:
     paths:
       - .trivycache/


### PR DESCRIPTION
looks like `cache_dir` is a global option while others are related to the `image` command

```sh
NAME:
   trivy - A simple and comprehensive vulnerability scanner for containers

USAGE:
   trivy [global options] command [command options] image_name

VERSION:
   0.8.0

COMMANDS:
   image, i   scan an image
   client, c  client mode
   server, s  server mode
   help, h    Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --quiet, -q        suppress progress bar and log output (default: false) [$TRIVY_QUIET]
   --debug, -d        debug mode (default: false) [$TRIVY_DEBUG]
   --cache-dir value  cache directory (default: "/root/.cache/trivy") [$TRIVY_CACHE_DIR]
   --help, -h         show help (default: false)
   --version, -v      print the version (default: false)
```