### PR TITLE
fix(notify): allow_failure

### DIFF
--- a/base_notify_github_stage.yml
+++ b/base_notify_github_stage.yml
@@ -6,6 +6,7 @@
 #
 .notify_stage: &notify_stage
   image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/git-deploy:1.51.0
+  allow_failure: true
   stage: .post
   dependencies: []
 


### PR DESCRIPTION
Dont stop pipeline when notifications fails. This can happen when the GH branch is deleted before the branch pipeline fully executed