### PR TITLE
feat: master branch and AUTO_DEVOPS_RELEASE_AUTO optims

### DIFF
--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -90,6 +90,8 @@ variables:
       when: never
     - if: "$CI_COMMIT_TAG"
       when: never
+    - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_BRANCH == 'master'"
+      when: never
     - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/"
       when: on_success
     - when: manual
@@ -105,7 +107,9 @@ Trigger Release:
       when: never
     - <<: *autodevops_release_trigger_rule2
       when: never
-    - if: "$RELEASE"
+    - <<: *autodevops_master_trigger_rule
+      when: always
+    - if:
   variables:
     GIT_DEPTH: 4242
     SEMANTIC_RELEASE_ARGS: ""

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -58,7 +58,7 @@ variables:
 .trigger_rule: &autodevops_trigger_rule
   if: "$PRODUCTION || $RELEASE"
 .release_trigger_rule: &autodevops_release_trigger_rule
-  if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
+  if: '($CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta") || ($CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/)'
 .master_trigger_rule: &autodevops_master_trigger_rule
   if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -60,9 +60,9 @@ variables:
 .release_trigger_rule: &autodevops_release_trigger_rule
   if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
 .release_trigger_rule2: &autodevops_release_trigger_rule2
-  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_TAG == "" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
+  if: '$CI_COMMIT_BRANCH == "master" && "$${CI_COMMIT_TAG}" == "" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_TAG == "" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
+  if: '$CI_COMMIT_BRANCH == "master" && "$${CI_COMMIT_TAG}" == "" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -62,7 +62,7 @@ variables:
 .release_trigger_rule2: &autodevops_release_trigger_rule2
   if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /chore\(release\)/'
+  if: "$CI_COMMIT_BRANCH == 'master' && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /chore(release)/"
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -62,7 +62,7 @@ variables:
 .release_trigger_rule2: &autodevops_release_trigger_rule2
   if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /chore(release)/'
+  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /chore\(release\)/'
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -60,9 +60,9 @@ variables:
 .release_trigger_rule: &autodevops_release_trigger_rule
   if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
 .release_trigger_rule2: &autodevops_release_trigger_rule2
-  if: '$CI_COMMIT_BRANCH == "master" && "$${CI_COMMIT_TAG}" == "" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
+  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && "$${CI_COMMIT_TAG}" == "" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
+  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -60,9 +60,9 @@ variables:
 .release_trigger_rule: &autodevops_release_trigger_rule
   if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
 .release_trigger_rule2: &autodevops_release_trigger_rule2
-  if: "$CI_COMMIT_BRANCH == 'master' && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
+  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_TAG == "" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
+  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_TAG == "" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -103,10 +103,10 @@ Trigger Release:
   extends:
     - .base_semantic_release_stage
   rules:
-    - <<: *autodevops_release_trigger_rule
-      when: never
-    - <<: *autodevops_release_trigger_rule2
-      when: never
+    # - <<: *autodevops_release_trigger_rule
+    #   when: never
+    # - <<: *autodevops_release_trigger_rule2
+    #   when: never
     - <<: *autodevops_master_trigger_rule
       when: always
   variables:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -69,6 +69,12 @@ variables:
 #
 #
 
+.release_trigger_rule:
+  rules:
+    - &autodevops_release_trigger_rule
+      if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
+      when: never
+
 .autodevops_trigger_release:
   extends:
     - .base_trigger_release_stage
@@ -76,6 +82,7 @@ variables:
   stage: .post
   rules:
     - <<: *autodevops_global_skip_case
+    - <<: *autodevops_release_trigger_rule
     - if: "$CI_COMMIT_TAG"
       when: never
     - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -58,11 +58,11 @@ variables:
 .trigger_rule: &autodevops_trigger_rule
   if: "$PRODUCTION || $RELEASE"
 .release_trigger_rule: &autodevops_release_trigger_rule
-  if: "$CI_COMMIT_BRANCH != 'master' && $CI_COMMIT_BRANCH != 'alpha' && $CI_COMMIT_BRANCH != 'beta'"
+  if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
 .release_trigger_rule2: &autodevops_release_trigger_rule2
-  if: "$CI_COMMIT_BRANCH == 'master' && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
+  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: "$CI_COMMIT_BRANCH == 'master' && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/"
+  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 
 .autodevops_base_rules:
   rules:
@@ -109,7 +109,6 @@ Trigger Release:
       when: never
     - <<: *autodevops_master_trigger_rule
       when: always
-    - if:
   variables:
     GIT_DEPTH: 4242
     SEMANTIC_RELEASE_ARGS: ""

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -57,23 +57,23 @@ variables:
   if: "$PRODUCTION && $CI_COMMIT_TAG"
 .trigger_rule: &autodevops_trigger_rule
   if: "$PRODUCTION || $RELEASE"
+.release_trigger_rule: &autodevops_release_trigger_rule
+  if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
+.master_trigger_rule: &autodevops_master_trigger_rule
+  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 
 .autodevops_base_rules:
   rules:
     - &autodevops_global_skip_case
       <<: *autodevops_trigger_rule
       when: never
+    - <<: *autodevops_master_trigger_rule
+      when: never
     - when: on_success
 
 #
 #
 #
-
-.release_trigger_rule:
-  rules:
-    - &autodevops_release_trigger_rule
-      if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
-      when: never
 
 .autodevops_trigger_release:
   extends:
@@ -83,6 +83,7 @@ variables:
   rules:
     - <<: *autodevops_global_skip_case
     - <<: *autodevops_release_trigger_rule
+      when: never
     - if: "$CI_COMMIT_TAG"
       when: never
     - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
@@ -98,6 +99,8 @@ Trigger Release:
   extends:
     - .base_semantic_release_stage
   rules:
+    - <<: *autodevops_release_trigger_rule
+      when: never
     - if: "$RELEASE"
   variables:
     GIT_DEPTH: 4242
@@ -143,6 +146,8 @@ Trigger Production:
   rules:
     - <<: *autodevops_trigger_rule
       when: never
+    - <<: *autodevops_master_trigger_rule
+      when: never
     - if: "$AUTO_DEVOPS_QUALITY_DISABLED"
       when: never
     - when: always
@@ -160,6 +165,8 @@ Trigger Production:
 .autodevops_test:
   rules:
     - <<: *autodevops_trigger_rule
+      when: never
+    - <<: *autodevops_master_trigger_rule
       when: never
     - if: "$AUTO_DEVOPS_TEST_DISABLED"
       when: never
@@ -232,6 +239,8 @@ Trigger Production:
   rules:
     - if: "$PRODUCTION || $RELEASE || $CI_COMMIT_TAG"
       when: never
+    - <<: *autodevops_master_trigger_rule
+      when: never
     - when: on_success
   variables:
     KOSKO_APPEND_YAML_FROM: .k8s/environments/dev/manifests
@@ -291,6 +300,8 @@ Production:
   stage: .post
   rules:
     - if: "$PRODUCTION || $RELEASE || $CI_COMMIT_TAG"
+      when: never
+    - <<: *autodevops_master_trigger_rule
       when: never
     - when: manual
   environment:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -90,9 +90,7 @@ variables:
       when: never
     - if: "$CI_COMMIT_TAG"
       when: never
-    - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
-      when: never
-    - if: "$AUTO_DEVOPS_RELEASE_AUTO"
+    - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/"
       when: on_success
     - when: manual
 

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -58,11 +58,11 @@ variables:
 .trigger_rule: &autodevops_trigger_rule
   if: "$PRODUCTION || $RELEASE"
 .release_trigger_rule: &autodevops_release_trigger_rule
-  if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
+  if: "$CI_COMMIT_BRANCH != 'master' && $CI_COMMIT_BRANCH != 'alpha' && $CI_COMMIT_BRANCH != 'beta'"
 .release_trigger_rule2: &autodevops_release_trigger_rule2
-  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
+  if: "$CI_COMMIT_BRANCH == 'master' && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
+  if: "$CI_COMMIT_BRANCH == 'master' && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/"
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -62,7 +62,7 @@ variables:
 .release_trigger_rule2: &autodevops_release_trigger_rule2
   if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
-  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
+  if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /chore(release)/'
 
 .autodevops_base_rules:
   rules:

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -60,7 +60,7 @@ variables:
 .release_trigger_rule: &autodevops_release_trigger_rule
   if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
 .release_trigger_rule2: &autodevops_release_trigger_rule2
-  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
+  if: "$CI_COMMIT_BRANCH == 'master' && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
 .master_trigger_rule: &autodevops_master_trigger_rule
   if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 

--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -58,7 +58,9 @@ variables:
 .trigger_rule: &autodevops_trigger_rule
   if: "$PRODUCTION || $RELEASE"
 .release_trigger_rule: &autodevops_release_trigger_rule
-  if: '($CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta") || ($CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/)'
+  if: '$CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "alpha" && $CI_COMMIT_BRANCH != "beta"'
+.release_trigger_rule2: &autodevops_release_trigger_rule2
+  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^chore(release): version/'
 .master_trigger_rule: &autodevops_master_trigger_rule
   if: '$CI_COMMIT_BRANCH == "master" && $AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE !~ /^chore(release): version/'
 
@@ -84,6 +86,8 @@ variables:
     - <<: *autodevops_global_skip_case
     - <<: *autodevops_release_trigger_rule
       when: never
+    - <<: *autodevops_release_trigger_rule2
+      when: never
     - if: "$CI_COMMIT_TAG"
       when: never
     - if: "$AUTO_DEVOPS_RELEASE_AUTO && $CI_COMMIT_MESSAGE =~ /^chore(release): version/"
@@ -100,6 +104,8 @@ Trigger Release:
     - .base_semantic_release_stage
   rules:
     - <<: *autodevops_release_trigger_rule
+      when: never
+    - <<: *autodevops_release_trigger_rule2
       when: never
     - if: "$RELEASE"
   variables:


### PR DESCRIPTION
Optims with `AUTO_DEVOPS_RELEASE_AUTO` and master branch

 - [x] skip release pipeline on other branches than master, alpha, beta
 - [x] skip release pipeline when master and a release commit
 - [x] skip test/build/deploy on master when `$AUTO_DEVOPS_RELEASE_AUTO` and not a release commit

when `AUTO_DEVOPS_RELEASE_AUTO` master is never deployed, but preprod is