### PR TITLE
feat(kosko): only install production deps when deploying

### DIFF
--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -32,7 +32,7 @@ variables:
     #
     - yarn config set cache-folder ${CI_PROJECT_DIR}/.cache/yarn
     - cd ${K8S_FOLDER}
-    - yarn --frozen-lockfile --prefer-offline --link-duplicates
+    - yarn --production --frozen-lockfile --prefer-offline --link-duplicates
     #
     - echo "kosko generate ${KOSKO_GENERATE_ARGS} >> ${CI_PROJECT_DIR}/manifest.yaml"
     - kosko generate ${KOSKO_GENERATE_ARGS} > ${CI_PROJECT_DIR}/manifest.yaml


### PR DESCRIPTION
As we now have a testing process for kosko-charts, I would argue that we know have a clear difference between what we need to _deploy_ and what we need to _test_. If we want to fix a testing framework for kosko-charts testing, we should ensure that we do not install dev dependencies when deploying.

BREAKING CHANGE: You will want to move your dependencies in the "dependencies" of your `package.json`

```diff
   "dependencies": {
     "@kosko/env": "^0.5.2",
     "@socialgouv/kosko-charts": "^4.0.0-alpha.8",
     "@socialgouv/kosko-charts": "^4.0.0-alpha.8",
-    "kubernetes-models": "^0.8.1"
+    "kubernetes-models": "^0.8.1",
+    "kosko": "^0.9.2",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
-    "@types/jest": "^26.0.16",
     "@types/node": "^14.11.10",
-    "dotenv": "^8.2.0",
-    "kosko": "^0.9.2",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "@types/jest": "^26.0.16",
+    "dotenv": "^8.2.0"
   }
 }
```