### PR TITLE
fix(deploy): ensure manifest.yaml exist to print

### DIFF
--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -51,7 +51,7 @@ variables:
       echo ""
       echo ""
       echo "******************************************************************************************"
-      cat ${CI_PROJECT_DIR}/manifest.yaml | grep "\- host:" | sed -e s/-\ host\:\ /🚀\ https\:\\/\\//
+      [[ -f "${CI_PROJECT_DIR}/manifest.yaml" ]] && cat "${CI_PROJECT_DIR}/manifest.yaml" | grep "\- host:" | sed -e s/-\ host\:\ /🚀\ https\:\\/\\//
       echo "******************************************************************************************"
       echo ""
       echo ""


### PR DESCRIPTION
Job fail when there is no manifest.yaml to print the deployed hosts

balot

https://gitlab.factory.social.gouv.fr/SocialGouv/cdtn-admin/-/jobs/1169970