### PR TITLE
feat(autodevops)!: use generic TRIGGER

### DIFF
--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -58,7 +58,7 @@ variables:
 .production_rule: &autodevops_production_rule
   if: "$PRODUCTION && $CI_COMMIT_TAG"
 .trigger_rule: &autodevops_trigger_rule
-  if: "$PRODUCTION || $RELEASE"
+  if: "$PRODUCTION || $TRIGGER"
 
 .autodevops_base_rules:
   rules:
@@ -93,7 +93,7 @@ Trigger Release:
   extends:
     - .base_semantic_release_stage
   rules:
-    - if: "$RELEASE"
+    - if: $TRIGGER == "RELEASE"
   variables:
     GIT_DEPTH: 4242
     SEMANTIC_RELEASE_ARGS: ""
@@ -268,7 +268,7 @@ Trigger Production:
   extends:
     - .deploy_stage
   rules:
-    - if: "$PRODUCTION || $RELEASE || $CI_COMMIT_TAG"
+    - if: "$PRODUCTION || $TRIGGER || $CI_COMMIT_TAG"
       when: never
     - when: on_success
   variables:
@@ -288,7 +288,7 @@ Review:
     - .deploy_stage
     - .autodevops_review
   rules:
-    - if: "$PRODUCTION || $RELEASE"
+    - if: "$PRODUCTION || $TRIGGER"
       when: never
     - if: "$CI_COMMIT_TAG"
   variables:
@@ -328,7 +328,7 @@ Production:
     - .base_docker_kubectl_image_stage
   stage: .post
   rules:
-    - if: "$PRODUCTION || $RELEASE || $CI_COMMIT_TAG"
+    - if: "$PRODUCTION || $TRIGGER || $CI_COMMIT_TAG"
       when: never
     - when: manual
   environment:
@@ -353,7 +353,7 @@ Stop review:
     name: preprod${AUTO_DEVOPS_PREPROD_ENVIRONMENT_NAME}
     action: stop
   rules:
-    - if: "$PRODUCTION || $RELEASE"
+    - if: "$PRODUCTION || $TRIGGER"
       when: never
     - if: "$CI_COMMIT_TAG"
       when: manual
@@ -369,7 +369,7 @@ Stop preprod:
     - .base_notify_pending_stage
   stage: Deploy
   rules:
-    - if: "$RELEASE"
+    - if: "$TRIGGER"
       when: never
     - if: "$AUTO_DEVOPS_NOTIFY_DISABLED"
       when: never
@@ -401,7 +401,7 @@ Notify Starting Deployment:
     - .base_notify_fail_stage
     - .notify
   rules:
-    - if: "$RELEASE"
+    - if: "$TRIGGER"
       when: never
     - if: "$AUTO_DEVOPS_NOTIFY_DISABLED"
       when: never
@@ -414,7 +414,7 @@ Notify Fail:
     - .base_notify_success_stage
     - .notify
   rules:
-    - if: "$RELEASE"
+    - if: "$TRIGGER"
       when: never
     - if: "$AUTO_DEVOPS_NOTIFY_DISABLED"
       when: never

--- a/base_trigger_stage.yml
+++ b/base_trigger_stage.yml
@@ -23,7 +23,7 @@ variables:
   variables:
     TRIGGER_ARGS: >-
       --form ref="${CI_COMMIT_REF_NAME}"
-      --form variables[RELEASE]="true"
+      --form variables[TRIGGER]="RELEASE"
 
 .base_trigger_production_stage:
   extends:


### PR DESCRIPTION


<img width=100% src=https://media.giphy.com/media/iqH4z3L6lCVuiomRUe/giphy.gif />


---


**BREAKING CHANGE**: Manual releases will need to go through the `TRIGGER` env variable now

No impact on existing `Trigger Production` and `Trigger Release` jobs.
But other jobs will need to do `TRIGGER="<my stuff>"`
