### PR TITLE
feat: kosko deploy with gitlab-deploy image

### DIFF
--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -34,15 +34,17 @@ variables:
     - |
       if [[ -d "${CI_PROJECT_DIR}/.socialgouv" ]]; then
         echo "Use .socialgouv config."
-        rm -rf /k8s/.socialgouv
-        cp -r ${CI_PROJECT_DIR}/.socialgouv /k8s/
-        if [[ -d "/k8s/.socialgouv/environments" ]]; then
-          cp -r /k8s/.socialgouv/environments/* /k8s/.k8s/environments/
+        mkdir socialgouv
+        git clone --depth 1 --branch v1.5.1 https://github.com/SocialGouv/k8s socialgouv
+        rm -rf ./socialgouv/.socialgouv
+        cp -r ${CI_PROJECT_DIR}/.socialgouv ./socialgouv/
+        if [[ -d "./socialgouv/.socialgouv/environments" ]]; then
+          cp -r ./socialgouv/.socialgouv/environments/* ./socialgouv/.k8s/environments/
         fi
-        if [[ -d "/k8s/.socialgouv/components" ]]; then
-          cp -r /k8s/.socialgouv/components/* /k8s/.k8s/components/
+        if [[ -d "./socialgouv/.socialgouv/components" ]]; then
+          cp -r ./socialgouv/.socialgouv/components/* ./socialgouv/.k8s/components/
         fi
-        cd /k8s/.k8s
+        cd ./socialgouv/.k8s
       else
         yarn config set cache-folder ${CI_PROJECT_DIR}/.cache/yarn
         cd ${K8S_FOLDER}

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -49,11 +49,13 @@ variables:
         yarn config set cache-folder ${CI_PROJECT_DIR}/.cache/yarn
         cd ${K8S_FOLDER}
       fi
+    - pwd
+    - cat package.json
     - echo "yarn --production --frozen-lockfile --prefer-offline --link-duplicates"
     - yarn --production --frozen-lockfile --prefer-offline --link-duplicates
     #
-    - echo "kosko generate ${KOSKO_GENERATE_ARGS} >> ${CI_PROJECT_DIR}/manifest.yaml"
-    - kosko generate ${KOSKO_GENERATE_ARGS} > ${CI_PROJECT_DIR}/manifest.yaml
+    - echo "yarn kosko generate ${KOSKO_GENERATE_ARGS} >> ${CI_PROJECT_DIR}/manifest.yaml"
+    - yarn kosko generate ${KOSKO_GENERATE_ARGS} > ${CI_PROJECT_DIR}/manifest.yaml
     #
     - cd -
     - |

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -22,7 +22,7 @@ variables:
 .base_deploy_kosko_stage:
   stage: Deploy
   # todo: use gitlab-deploy image
-  image: ghcr.io/socialgouv/docker/kubectl:sha-12af17fb38dc2c19e2101b2a2b28a82b2ca4f24b
+  image: ghcr.io/socialgouv/docker/ci-deploy:6.36.0
   dependencies: []
   cache:
     key:

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -36,7 +36,7 @@ variables:
     - |
       if [[ -d "${CI_PROJECT_DIR}/.socialgouv" ]]; then
         echo "Use .socialgouv config."
-        echo "Use no-k8s version $NOK8S_VERSION"
+        echo "Using no-k8s version $NOK8S_VERSION"
         git clone --depth 1 --branch $NOK8S_VERSION https://github.com/SocialGouv/k8s socialgouv
         rm -rf ./socialgouv/.socialgouv
         cp -r ${CI_PROJECT_DIR}/.socialgouv ./socialgouv/

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -38,7 +38,6 @@ variables:
       if [[ -d "${CI_PROJECT_DIR}/.socialgouv" ]]; then
         echo "Use .socialgouv config."
         echo "Use no-k8s version $NOK8S_VERSION"
-        mkdir socialgouv
         git clone --depth 1 --branch $NOK8S_VERSION https://github.com/SocialGouv/k8s socialgouv
         rm -rf ./socialgouv/.socialgouv
         cp -r ${CI_PROJECT_DIR}/.socialgouv ./socialgouv/

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -3,6 +3,7 @@
 variables:
   K8S_FOLDER: ${CI_PROJECT_DIR}/.k8s
   KOSKO_GENERATE_ARGS: ""
+  # renovate: datasource=github-releases depName=socialgouv/k8s
   NOK8S_VERSION: v1.6.0
 
 .print_env: &print_env |
@@ -20,6 +21,7 @@ variables:
 
 .base_deploy_kosko_stage:
   stage: Deploy
+  # todo: use gitlab-deploy image
   image: ghcr.io/socialgouv/docker/kubectl:sha-12af17fb38dc2c19e2101b2a2b28a82b2ca4f24b
   dependencies: []
   cache:
@@ -35,8 +37,8 @@ variables:
     - |
       if [[ -d "${CI_PROJECT_DIR}/.socialgouv" ]]; then
         echo "Use .socialgouv config."
-        mkdir socialgouv
         echo "Use no-k8s version $NOK8S_VERSION"
+        mkdir socialgouv
         git clone --depth 1 --branch $NOK8S_VERSION https://github.com/SocialGouv/k8s socialgouv
         rm -rf ./socialgouv/.socialgouv
         cp -r ${CI_PROJECT_DIR}/.socialgouv ./socialgouv/
@@ -51,8 +53,6 @@ variables:
         yarn config set cache-folder ${CI_PROJECT_DIR}/.cache/yarn
         cd ${K8S_FOLDER}
       fi
-    - pwd
-    - cat package.json
     - echo "yarn --production --frozen-lockfile --prefer-offline --link-duplicates"
     - yarn --production --frozen-lockfile --prefer-offline --link-duplicates
     #

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -19,7 +19,7 @@ variables:
 
 .base_deploy_kosko_stage:
   stage: Deploy
-  image: ghcr.io/socialgouv/docker/kubectl:6.11.0
+  image: ghcr.io/socialgouv/docker/kubectl:tests
   dependencies: []
   cache:
     key:

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -19,7 +19,7 @@ variables:
 
 .base_deploy_kosko_stage:
   stage: Deploy
-  image: ghcr.io/socialgouv/docker/kubectl:tests
+  image: ghcr.io/socialgouv/docker/kubectl:sha-12af17fb38dc2c19e2101b2a2b28a82b2ca4f24b
   dependencies: []
   cache:
     key:

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -3,6 +3,7 @@
 variables:
   K8S_FOLDER: ${CI_PROJECT_DIR}/.k8s
   KOSKO_GENERATE_ARGS: ""
+  NOK8S_VERSION: v1.6.0
 
 .print_env: &print_env |
   printenv | grep \
@@ -35,7 +36,8 @@ variables:
       if [[ -d "${CI_PROJECT_DIR}/.socialgouv" ]]; then
         echo "Use .socialgouv config."
         mkdir socialgouv
-        git clone --depth 1 --branch v1.5.1 https://github.com/SocialGouv/k8s socialgouv
+        echo "Use no-k8s version $NOK8S_VERSION"
+        git clone --depth 1 --branch $NOK8S_VERSION https://github.com/SocialGouv/k8s socialgouv
         rm -rf ./socialgouv/.socialgouv
         cp -r ${CI_PROJECT_DIR}/.socialgouv ./socialgouv/
         if [[ -d "./socialgouv/.socialgouv/environments" ]]; then

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -54,8 +54,8 @@ variables:
     - echo "yarn --production --frozen-lockfile --prefer-offline --link-duplicates"
     - yarn --production --frozen-lockfile --prefer-offline --link-duplicates
     #
-    - echo "yarn kosko generate ${KOSKO_GENERATE_ARGS} >> ${CI_PROJECT_DIR}/manifest.yaml"
-    - yarn kosko generate ${KOSKO_GENERATE_ARGS} > ${CI_PROJECT_DIR}/manifest.yaml
+    - echo "yarn -s kosko generate ${KOSKO_GENERATE_ARGS} >> ${CI_PROJECT_DIR}/manifest.yaml"
+    - yarn -s kosko generate ${KOSKO_GENERATE_ARGS} > ${CI_PROJECT_DIR}/manifest.yaml
     #
     - cd -
     - |

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -19,7 +19,7 @@ variables:
 
 .base_deploy_kosko_stage:
   stage: Deploy
-  image: ghcr.io/socialgouv/docker/no-k8s:6.11.0
+  image: ghcr.io/socialgouv/docker/kubectl:6.11.0
   dependencies: []
   cache:
     key:
@@ -46,8 +46,9 @@ variables:
       else
         yarn config set cache-folder ${CI_PROJECT_DIR}/.cache/yarn
         cd ${K8S_FOLDER}
-        yarn --production --frozen-lockfile --prefer-offline --link-duplicates
       fi
+    - echo "yarn --production --frozen-lockfile --prefer-offline --link-duplicates"
+    - yarn --production --frozen-lockfile --prefer-offline --link-duplicates
     #
     - echo "kosko generate ${KOSKO_GENERATE_ARGS} >> ${CI_PROJECT_DIR}/manifest.yaml"
     - kosko generate ${KOSKO_GENERATE_ARGS} > ${CI_PROJECT_DIR}/manifest.yaml


### PR DESCRIPTION
replace dependency to nok8s docker image with [ci-deploy image](https://github.com/SocialGouv/docker/tree/master/ci-deploy)

 - nok8s version is maintained by renovate
 - kosko dependencies are download at runtime, based on project dependencies

this remove dependencies to docker images nk8s and kosko 

one can use a specific nok8s version in its pipeline with the variable `NOK8S_VERSION`