### PR TITLE
fix(autodevops): skip post-release master pipeline

### DIFF
--- a/autodevops.yml
+++ b/autodevops.yml
@@ -5,7 +5,7 @@ include:
 
 workflow:
   rules:
-    - if: '($CI_COMMIT_REF_NAME=="master" || $CI_COMMIT_REF_NAME=="main") && $CI_COMMIT_MESSAGE =~ /^chore\(release\):$/'
+    - if: '($CI_COMMIT_REF_NAME=="master" || $CI_COMMIT_REF_NAME=="main") && $CI_COMMIT_MESSAGE =~ /^chore\(release\):/'
       when: never
     - when: always
       

--- a/autodevops.yml
+++ b/autodevops.yml
@@ -7,6 +7,7 @@ workflow:
   rules:
     - if: ($CI_COMMIT_REF_NAME === 'master' || $CI_COMMIT_REF_NAME === 'main') && $CI_COMMIT_MESSAGE =~ /^chore\(release\):$/
       when: never
+    - when: always
       
 #
 

--- a/autodevops.yml
+++ b/autodevops.yml
@@ -8,7 +8,7 @@ workflow:
     - if: '($CI_COMMIT_REF_NAME=="master" || $CI_COMMIT_REF_NAME=="main") && $CI_COMMIT_MESSAGE =~ /^chore\(release\):/'
       when: never
     - when: always
-      
+
 #
 
 Install:

--- a/autodevops.yml
+++ b/autodevops.yml
@@ -3,6 +3,11 @@
 include:
   - /base_autodevops.yml
 
+workflow:
+  rules:
+    - if: ($CI_COMMIT_REF_NAME === 'master' || $CI_COMMIT_REF_NAME === 'main') && $CI_COMMIT_MESSAGE =~ /^chore\(release\):$/
+      when: never
+      
 #
 
 Install:

--- a/autodevops.yml
+++ b/autodevops.yml
@@ -5,7 +5,7 @@ include:
 
 workflow:
   rules:
-    - if: ($CI_COMMIT_REF_NAME === 'master' || $CI_COMMIT_REF_NAME === 'main') && $CI_COMMIT_MESSAGE =~ /^chore\(release\):$/
+    - if: '($CI_COMMIT_REF_NAME=="master" || $CI_COMMIT_REF_NAME=="main") && $CI_COMMIT_MESSAGE =~ /^chore\(release\):$/'
       when: never
     - when: always
       


### PR DESCRIPTION
I dont think we have any reason to re-run the master pipeline on `chore(release):` commits, do we ?