### PR TITLE
feat(semantic_release): ignore subgroup on release github remote

### DIFF
--- a/base_semantic_release_stage.yml
+++ b/base_semantic_release_stage.yml
@@ -19,7 +19,7 @@ variables:
       - $CI_PROJECT_DIR/.yarn
   before_script:
     # Use github as origin
-    - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${CI_PROJECT_PATH}.git
+    - git remote set-url origin https://${GITHUB_TOKEN}@github.com/${CI_PROJECT_ROOT_NAMESPACE}/${CI_PROJECT_TITLE}.git
   script:
     # Set git to a branch
     - git checkout ${CI_COMMIT_REF_NAME}


### PR DESCRIPTION
<img width=100% src=https://media.giphy.com/media/SefgoJ2kTM1OCPE181/giphy.gif />

---

Correct Github remote errors when releasing from GitLab to GitHub repository.
As we are switching from direct cloning of GitHub repository hierarchy to GitLab sub groups per startup, we can't use the `CI_PROJECT_PATH` anymore to guess the GitHub repo to push too has it contains the GitLab subgroup that doesn't exit on Github resulting on the "classic" error : 

```sh
Error: Command failed with exit code 128: git ls-remote --heads https://[secure]@github.com/SocialGouv/archifiltre/archifiltre-statistics.git
remote: Not Found
```

The alternative could be using the `CI_PROJECT_ROOT_NAMESPACE` and `CI_PROJECT_TITLE` to reconstituate the GitHub flat repository hierarchy 
see https://docs.gitlab.com/ee/ci/variables/predefined_variables.html