### PR TITLE
fix(autodevops): increase envs lifetime

### DIFF
--- a/base_autodevops.yml
+++ b/base_autodevops.yml
@@ -276,7 +276,7 @@ Trigger Production:
     KOSKO_GENERATE_ARGS: >-
       --env dev
   environment:
-    auto_stop_in: 1 day
+    auto_stop_in: 3 day
     name: ${CI_COMMIT_REF_NAME}${AUTO_DEVOPS_DEV_ENVIRONMENT_NAME}
     on_stop: Stop review
     url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_NAME}.${KUBE_INGRESS_BASE_DOMAIN}


### PR DESCRIPTION
set a 3 days expiration for dev ens, 1 day is a bit short