### PR TITLE
fix(base_deploy_kosko_stage): force new cert-manager annotation

### DIFF
--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -61,7 +61,7 @@ variables:
           echo '---' \; -exec cat {} \; \
         >> ${CI_PROJECT_DIR}/manifest.yaml
       fi
-    - sed -i '' -e /certmanager.k8s.io\/cluster-issuer/cert-manager.io\/cluster-issuer/ ${CI_PROJECT_DIR}/manifest.yaml
+    - sed -i '' -e /certmanager.k8s.io\/cluster-issuer/cert-manager.io\/cluster-issuer/g ${CI_PROJECT_DIR}/manifest.yaml
     - cat ${CI_PROJECT_DIR}/manifest.yaml
     - |
       if [[ -n $AUTO_DEVOPS_ENABLE_KAPP ]]; then

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -61,6 +61,7 @@ variables:
           echo '---' \; -exec cat {} \; \
         >> ${CI_PROJECT_DIR}/manifest.yaml
       fi
+    # this enable legacy gitlab+nok8s repos (ex: medle)
     - sed -i -e /certmanager.k8s.io\/cluster-issuer/cert-manager.io\/cluster-issuer/g ${CI_PROJECT_DIR}/manifest.yaml
     - cat ${CI_PROJECT_DIR}/manifest.yaml
     - |

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -61,7 +61,7 @@ variables:
           echo '---' \; -exec cat {} \; \
         >> ${CI_PROJECT_DIR}/manifest.yaml
       fi
-    - sed -i '' -e /certmanager.k8s.io\/cluster-issuer/cert-manager.io\/cluster-issuer/g ${CI_PROJECT_DIR}/manifest.yaml
+    - sed -i -e /certmanager.k8s.io\/cluster-issuer/cert-manager.io\/cluster-issuer/g ${CI_PROJECT_DIR}/manifest.yaml
     - cat ${CI_PROJECT_DIR}/manifest.yaml
     - |
       if [[ -n $AUTO_DEVOPS_ENABLE_KAPP ]]; then

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -61,6 +61,8 @@ variables:
           echo '---' \; -exec cat {} \; \
         >> ${CI_PROJECT_DIR}/manifest.yaml
       fi
+    - sed -i '' -e /certmanager.k8s.io\/cluster-issuer/cert-manager.io\/cluster-issuer/ ${CI_PROJECT_DIR}/manifest.yaml
+    - cat ${CI_PROJECT_DIR}/manifest.yaml
     - |
       if [[ -n $AUTO_DEVOPS_ENABLE_KAPP ]]; then
         if [[ -z $PRODUCTION ]]; then

--- a/base_deploy_kosko_stage.yml
+++ b/base_deploy_kosko_stage.yml
@@ -19,7 +19,7 @@ variables:
 
 .base_deploy_kosko_stage:
   stage: Deploy
-  image: ghcr.io/socialgouv/docker/no-k8s:6.48.0
+  image: ghcr.io/socialgouv/docker/no-k8s:6.48.1
   dependencies: []
   cache:
     key:


### PR DESCRIPTION
Hack to allow legacy gitlab pipelines to use the new cert-manager annotation